### PR TITLE
feature/refactor

### DIFF
--- a/philo/Makefile
+++ b/philo/Makefile
@@ -11,6 +11,7 @@ DEPS		:= $(OBJS:.o=.d)
 CC			:= cc
 CFLAGS		:= -Wall -Wextra -Werror
 CPPFLAGS	:= -MMD -MP -I incs/
+LDFLAGS := -lpthread
 
 RM			:= rm -f
 RMDIR		+= -r
@@ -55,7 +56,7 @@ init:
 all: init $(NAME)
 
 $(NAME): Makefile $(OBJS)
-	@$(CC) $(CFLAGS) $(CPPFLAGS) -o $(NAME) $(OBJS)
+	@$(CC) $(CFLAGS) $(CPPFLAGS) -o $(NAME) $(OBJS) $(LDFLAGS)
 	@echo "\n$(GREEN_BOLD)✓ $(NAME) is ready $(RESETC)\n"
 
 $(BUILD_DIR)%.o: $(SRCSDIR)%.c

--- a/philo/incs/philo.h
+++ b/philo/incs/philo.h
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:18:01 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/19 10:50:55 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 12:00:03 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define PHILO_H
 
 # include <pthread.h>
+# include <stdbool.h>
 
 typedef struct s_fork
 {
@@ -26,7 +27,6 @@ typedef struct s_philo
 {
 	int				eat_counter;
 	int				id;
-	int				priority;
 	long long		last_time_eaten;
 	pthread_mutex_t	eater_mutex;
 	pthread_t		thread;
@@ -54,20 +54,21 @@ typedef struct s_data
 void		*routine(void *arg);
 
 void		cleanup(t_data *data);
-void		print_status(t_philo *philo, char *status);
-void		usleep_enhanced(time_t ms);
 void		eating(t_philo *philo);
+void		join_threads(t_data *data);
+void		monitor_philos(t_data *data);
+void		print_status(t_philo *philo, char *status);
 void		release_forks(t_philo *philo);
 void		sleep_think(t_philo *philo);
-void		join_threads(t_data *data);
+void		usleep_enhanced(time_t ms);
 
 int			check_sim_has_to_end(t_data *data);
 int			check_simulation_state(t_data *data);
-int			init_simulation(t_data *data);
-int			parser(int ac, char **av, t_data *data);
-int			simulation_start(t_data *data);
-int			take_fork(t_philo *philo);
-int			monitor_philos(t_data *data);
+
+bool		init_simulation(t_data *data);
+bool		parser(int ac, char **av, t_data *data);
+bool		simulation_start(t_data *data);
+bool		take_fork(t_philo *philo);
 
 time_t		get_time(void);
 

--- a/philo/srcs/init/initialization.c
+++ b/philo/srcs/init/initialization.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:15:52 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/16 08:15:53 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:45:58 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,63 +16,63 @@
 #include "philo.h"
 #include "common.h"
 
-static int	init_data_mutexes(t_data *data);
-static int	init_data(t_data *data);
-static int	init_forks(t_data *data);
-static int	init_philo(t_data *data);
+static bool	init_data_mutexes(t_data *data);
+static bool	init_data(t_data *data);
+static bool	init_forks(t_data *data);
+static bool	init_philo(t_data *data);
 
-int	init_simulation(t_data *data)
+bool	init_simulation(t_data *data)
 {
-	if (init_data(data) == -1)
-		return (-1);
-	if (init_forks(data) == -1)
+	if (!init_data(data))
+		return (false);
+	if (!init_forks(data))
 	{
 		cleanup(data);
-		return (-1);
+		return (false);
 	}
-	if (init_philo(data) == -1)
+	if (!init_philo(data))
 	{
 		cleanup(data);
-		return (-1);
+		return (false);
 	}
-	return (0);
+	return (true);
 }
 
-static int	init_data(t_data *data)
+static bool	init_data(t_data *data)
 {
 	data->philo = malloc(sizeof(t_philo) * data->nb_philos);
 	if (data->philo == NULL)
-		return (-1);
+		return (false);
 	data->forks = malloc(sizeof(t_fork) * data->nb_philos);
 	if (data->forks == NULL)
 	{
 		free(data->philo);
-		return (-1);
+		return (false);
 	}
 	memset(data->philo, 0, sizeof(t_philo) * data->nb_philos);
 	memset(data->forks, 0, sizeof(t_fork) * data->nb_philos);
-	if (init_data_mutexes(data) == -1)
+	if (!init_data_mutexes(data))
 	{
 		free(data->forks);
 		free(data->philo);
-		return (-1);
+		return (false);
 	}
-	return (0);
+	return (true);
 }
 
-static int	init_data_mutexes(t_data *data)
+static bool	init_data_mutexes(t_data *data)
 {
 	if (pthread_mutex_init(&data->mutex_printing, NULL) != 0)
-		return (-1);
+		return (false);
 	if (pthread_mutex_init(&data->mutex_sim_state, NULL) != 0)
 	{
 		pthread_mutex_destroy(&data->mutex_printing);
-		return (-1);
+		return (false);
 	}
-	return (0);
+	return (true);
 }
 
-static int	init_forks(t_data *data)
+static bool	init_forks(t_data *data)
 {
 	int	i;
 
@@ -92,14 +92,14 @@ static int	init_forks(t_data *data)
 			pthread_mutex_destroy(&data->mutex_printing);
 			pthread_mutex_destroy(&data->mutex_sim_state);
 			free(data->forks);
-			return (-1);
+			return (false);
 		}
 		i++;
 	}
-	return (0);
+	return (true);
 }
 
-static int	init_philo(t_data *data)
+static bool	init_philo(t_data *data)
 {
 	int	i;
 
@@ -110,7 +110,6 @@ static int	init_philo(t_data *data)
 		data->philo[i].r_fork = &data->forks[(i + 1) % data->nb_philos];
 		data->philo[i].id = i + 1;
 		data->philo[i].eat_counter = 0;
-		data->philo[i].priority = 0;
 		data->philo[i].data = data;
 		if (pthread_mutex_init(&data->philo[i].eater_mutex, NULL) != 0)
 		{
@@ -121,9 +120,9 @@ static int	init_philo(t_data *data)
 				i--;
 			}
 			free(data->philo);
-			return (-1);
+			return (false);
 		}
 		i++;
 	}
-	return (0);
+	return (true);
 }

--- a/philo/srcs/init/parser.c
+++ b/philo/srcs/init/parser.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:15:54 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/16 08:15:55 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:40:51 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ static inline int	ft_isdigit(int c)
 	return (0);
 }
 
-static int	literal_check(char **av)
+static bool	literal_check(char **av)
 {
 	static int	i = 1;
 	int			j;
@@ -57,35 +57,35 @@ static int	literal_check(char **av)
 			if (ft_isdigit(av[i][j]) == 0)
 			{
 				printf(LITERAL_ARGS);
-				return (-1);
+				return (false);
 			}
 			j++;
 		}
 		i++;
 	}
-	return (0);
+	return (true);
 }
 
-static int	check_params_validity(char **av, t_data *data)
+static bool	check_params_validity(char **av, t_data *data)
 {
-	if (literal_check(av) == -1)
-		return (-1);
+	if (!literal_check(av))
+		return (false);
 	if (data->nb_philos <= 0 \
 		|| data->tt_die <= 0 || data->tt_eat <= 0 \
 		|| data->tt_sleep <= 0 || (av[5] && data->nb_meal < 0))
 	{
 		printf(OOR_ARGS);
-		return (-1);
+		return (false);
 	}
 	if (av[5] && data->nb_meal == 0)
 	{
 		printf(LEAVE_TABLE);
-		return (-1);
+		return (false);
 	}
-	return (0);
+	return (true);
 }
 
-int	parser(int ac, char **av, t_data *data)
+bool	parser(int ac, char **av, t_data *data)
 {
 	if (ac != 5 && ac != 6)
 	{
@@ -93,7 +93,7 @@ int	parser(int ac, char **av, t_data *data)
 			printf(MISSING_ARGS);
 		else
 			printf(TOO_MANY_ARGS);
-		return (-1);
+		return (false);
 	}
 	data->nb_philos = atoi_strict(av[1]);
 	data->tt_die = atoi_strict (av[2]);
@@ -103,7 +103,7 @@ int	parser(int ac, char **av, t_data *data)
 		data->nb_meal = atoi_strict(av[5]);
 	else
 		data->nb_meal = -1;
-	if (check_params_validity(av, data) == -1)
-		return (-1);
-	return (0);
+	if (!check_params_validity(av, data))
+		return (false);
+	return (true);
 }

--- a/philo/srcs/philosophers.c
+++ b/philo/srcs/philosophers.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:16:11 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/16 08:16:12 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:46:55 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,11 +20,11 @@ int	main(int ac, char **av)
 	t_data	data;
 
 	memset(&data, 0, sizeof(t_data));
-	if (parser(ac, av, &data) == -1)
+	if (!parser(ac, av, &data))
 		return (EXIT_FAILURE);
-	if (init_simulation(&data) == -1)
+	if (!init_simulation(&data))
 		return (EXIT_FAILURE);
-	if (simulation_start(&data) == -1)
+	if (!simulation_start(&data))
 	{
 		cleanup(&data);
 		return (EXIT_FAILURE);

--- a/philo/srcs/routine/actions.c
+++ b/philo/srcs/routine/actions.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:15:56 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/19 12:44:18 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:56:03 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ void	eating(t_philo *philo)
 {
 	if (check_simulation_state(philo->data) == SIM_OFF)
 		return ;
-	if (take_fork(philo) == -1)
+	if (!take_fork(philo))
 		return ;
 	pthread_mutex_lock(&philo->eater_mutex);
 	philo->last_time_eaten = get_time();

--- a/philo/srcs/routine/fork.c
+++ b/philo/srcs/routine/fork.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:15:58 by gueberso          #+#    #+#             */
-/*   Updated: 2025/08/08 11:54:51 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 12:22:03 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,7 +96,7 @@ bool	take_fork(t_philo *philo)
 		if (try_take_first_fork(first))
 			if (try_take_second_fork(philo, first, second))
 				return (true);
-		usleep(500); // is it still necessary ? need to check on school computer later on
+		usleep(500);
 	}
 	return (false);
 }

--- a/philo/srcs/routine/fork.c
+++ b/philo/srcs/routine/fork.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:15:58 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/19 12:15:22 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:54:51 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,33 +38,33 @@ void	release_forks(t_philo *philo)
 	}
 }
 
-static int	try_take_first_fork(t_fork *fork)
+static bool	try_take_first_fork(t_fork *fork)
 {
-	int	result;
+	bool	result;
 
-	result = 0;
+	result = false;
 	pthread_mutex_lock(&fork->gatekeeper);
 	if (fork->status == AVAILABLE)
 	{
 		fork->status = UNAVAILABLE;
-		result = 1;
+		result = true;
 	}
 	pthread_mutex_unlock(&fork->gatekeeper);
 	return (result);
 }
 
-static int	try_take_second_fork(t_philo *philo, t_fork *first, t_fork *second)
+static bool	try_take_second_fork(t_philo *philo, t_fork *first, t_fork *second)
 {
-	int	result;
+	bool	result;
 
-	result = 0;
+	result = false;
 	pthread_mutex_lock(&second->gatekeeper);
 	if (second->status == AVAILABLE)
 	{
 		second->status = UNAVAILABLE;
 		print_status(philo, "has taken a fork");
 		print_status(philo, "has taken a fork");
-		result = 1;
+		result = true;
 	}
 	else
 	{
@@ -76,7 +76,7 @@ static int	try_take_second_fork(t_philo *philo, t_fork *first, t_fork *second)
 	return (result);
 }
 
-int	take_fork(t_philo *philo)
+bool	take_fork(t_philo *philo)
 {
 	t_fork	*first;
 	t_fork	*second;
@@ -95,8 +95,8 @@ int	take_fork(t_philo *philo)
 	{
 		if (try_take_first_fork(first))
 			if (try_take_second_fork(philo, first, second))
-				return (0);
-		usleep(500);
+				return (true);
+		usleep(500); // is it still necessary ? need to check on school computer later on
 	}
-	return (-1);
+	return (false);
 }

--- a/philo/srcs/routine/monitoring.c
+++ b/philo/srcs/routine/monitoring.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:15:49 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/19 10:50:42 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:47:25 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,7 +90,7 @@ static int	check_sim_status(t_data *data, int i)
 	return (0);
 }
 
-int	monitor_philos(t_data *data)
+void	monitor_philos(t_data *data)
 {
 	int	i;
 	int	should_stop;
@@ -115,5 +115,4 @@ int	monitor_philos(t_data *data)
 	}
 	i = -1;
 	join_threads(data);
-	return (0);
 }

--- a/philo/srcs/routine/routine.c
+++ b/philo/srcs/routine/routine.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:16:03 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/19 11:57:26 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:51:06 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,16 +16,16 @@
 #include "philo.h"
 #include "common.h"
 
-int	check_meal_counter(t_philo *philo)
+bool	check_meal_counter(t_philo *philo)
 {
-	int	result;
+	bool	result;
 
 	pthread_mutex_lock(&philo->eater_mutex);
 	if (philo->data->nb_meal != -1 \
 		&& philo->eat_counter >= philo->data->nb_meal)
-		result = -1;
+		result = false;
 	else
-		result = 0;
+		result = true;
 	pthread_mutex_unlock(&philo->eater_mutex);
 	return (result);
 }
@@ -45,7 +45,7 @@ static void	initial_stagger(t_philo *philo)
 	else if (philo->id % 3 == 0)
 		delay = 1;
 	else
-		delay = 0;
+		return ;
 	if (delay > 0)
 		usleep_enhanced(delay);
 }
@@ -67,7 +67,7 @@ void	*routine(void *arg)
 	while (check_simulation_state(philo->data) == SIM_ON)
 	{
 		usleep_enhanced(1);
-		if (check_meal_counter(philo) == -1)
+		if (!check_meal_counter(philo))
 			break ;
 		eating(philo);
 		if (check_simulation_state(philo->data) == SIM_OFF)

--- a/philo/srcs/routine/routine.c
+++ b/philo/srcs/routine/routine.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:16:03 by gueberso          #+#    #+#             */
-/*   Updated: 2025/08/08 11:51:06 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 12:19:08 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,8 +46,7 @@ static void	initial_stagger(t_philo *philo)
 		delay = 1;
 	else
 		return ;
-	if (delay > 0)
-		usleep_enhanced(delay);
+	usleep_enhanced(delay);
 }
 
 void	*routine(void *arg)

--- a/philo/srcs/routine/simulation.c
+++ b/philo/srcs/routine/simulation.c
@@ -6,7 +6,7 @@
 /*   By: gueberso <gueberso@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 08:16:05 by gueberso          #+#    #+#             */
-/*   Updated: 2025/04/16 08:16:06 by gueberso         ###   ########.fr       */
+/*   Updated: 2025/08/08 11:46:25 by gueberso         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ int	check_simulation_state(t_data *data)
 	return (state);
 }
 
-int	simulation_start(t_data *data)
+bool	simulation_start(t_data *data)
 {
 	int	i;
 
@@ -35,7 +35,7 @@ int	simulation_start(t_data *data)
 		data->philo[i].last_time_eaten = data->start;
 		if (pthread_create(&data->philo[i].thread, NULL, routine, \
 														&data->philo[i]) != 0)
-			return (-1);
+			return (false);
 	}
-	return (0);
+	return (true);
 }


### PR DESCRIPTION
This pull request refactors the philo project codebase to consistently use `bool` return types instead of `int` for functions that indicate success or failure. It also removes the unused `priority` field from the `t_philo` struct and updates the Makefile to properly link the pthread library. These changes improve code clarity, safety, and portability.

### Refactoring return types for clarity and safety

* Changed return types of initialization, parsing, simulation, and fork-related functions from `int` to `bool`, updating their implementations and usage throughout the codebase for clearer success/failure semantics.

* Updated the function signatures and logic for thread monitoring and meal counter checks to use `void` and `bool` respectively, further clarifying intent.

### Code cleanup and structure changes

* Removed the unused `priority` member from the `t_philo` struct and its initialization, reducing unnecessary complexity (`philo/incs/philo.h`, `philo/srcs/init/initialization.c`).

* Added `#include <stdbool.h>` to headers and source files to support the new boolean return types (`philo/incs/philo.h`).

### Build system improvements

* Added `-lpthread` to `LDFLAGS` in the Makefile and updated the link command to ensure proper linking of pthreads for thread support (`philo/Makefile`).

---

These changes collectively make the codebase easier to read, maintain, and less error-prone by making success/failure checks explicit and ensuring proper thread library linkage.